### PR TITLE
Support multi language sites

### DIFF
--- a/index.php
+++ b/index.php
@@ -9,6 +9,7 @@ Kirby::plugin('pechente/kirby-password-guard', [
     'routes' => [
         [
             'pattern' => 'password-guard',
+            'language' => '*',
             'method' => 'POST',
             'action' => function () {
                 $password = get('password');


### PR DESCRIPTION
Set the language scope to *, so the password-guard route will listen to all languages.