### PR TITLE
Replaced stylesheet path from media url to dist url

### DIFF
--- a/templates/password-guard.php
+++ b/templates/password-guard.php
@@ -6,7 +6,7 @@
 
   <title><?= $page->title() ?></title>
 
-  <link rel="stylesheet" href="<?= $kirby->url('media') . '/panel/' . $kirby->versionHash() . '/css/style.min.css' ?>">
+  <style><?php F::load($kirby->root('kirby') . '/panel/dist/css/style.min.css'); ?></style>
 </head>
 <body>
   <div class="k-panel k-panel-outside">


### PR DESCRIPTION
If the media folder (e.g. `media/panel/1556e47a368dd610ee09cd444583f388/css/style.min.css`) does not exist, no stylesheets are available and the layout of the page is destroyed. The media folder is only created by accessing `/panel`, but not by accessing `/`.
However, the css file in the kirby dist folder (`kirby/panel/dist/css/style.min.css`) is always available and can be loaded inline without any problems. 