### PR TITLE
A few visual and accessibility fixes for the default template

### DIFF
--- a/templates/password-guard.php
+++ b/templates/password-guard.php
@@ -9,7 +9,7 @@
   <style><?php F::load($kirby->root('kirby') . '/panel/dist/css/style.min.css'); ?></style>
 </head>
 <body>
-  <div class="k-panel k-panel-outside">
+  <main class="k-panel k-panel-outside">
     <div class="k-dialog k-login k-login-dialog">
       <?php if($page->passwordIncorrect()->toBool()): ?>
       <div data-theme="error" class="k-notification k-login-alert">
@@ -24,12 +24,11 @@
       <div class="k-dialog-body">
         <form class="k-login-form" method="post" action="<?= $page->url() ?>">
           <div class="k-login-fields">
-            <header class="k-field-header">
-              <label class="k-label" title="<?= t('password') ?>">
+            <div class="k-field-header">
               <label for="password" class="k-label" title="<?= t('password') ?>">
                 <span class="k-label-text"><?= t('password') ?></span>
               </label>
-            </header>
+            </div>
             <div class="k-input">
               <span class="k-input-element">
                 <input type="password" name="password" id="password" class="k-password-input k-string-input" autofocus required>
@@ -51,7 +50,7 @@
         </form>
       </div>
     </div>
-  </div>
+  </main>
 
   <script>
     document.addEventListener('DOMContentLoaded', function () {

--- a/templates/password-guard.php
+++ b/templates/password-guard.php
@@ -26,6 +26,7 @@
           <div class="k-login-fields">
             <header class="k-field-header">
               <label class="k-label" title="<?= t('password') ?>">
+              <label for="password" class="k-label" title="<?= t('password') ?>">
                 <span class="k-label-text"><?= t('password') ?></span>
               </label>
             </header>

--- a/templates/password-guard.php
+++ b/templates/password-guard.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<?= $kirby->language()?->code() ?>">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0">

--- a/templates/password-guard.php
+++ b/templates/password-guard.php
@@ -31,7 +31,7 @@
             </header>
             <div class="k-input">
               <span class="k-input-element">
-                <input type="password" name="password" id="password" class="k-text-input" autofocus required>
+                <input type="password" name="password" id="password" class="k-password-input k-string-input" autofocus required>
                 <input type="hidden" name="redirect" value="<?= $page->redirect() ?>">
               </span>
               <span class="k-input-icon">


### PR DESCRIPTION
Hi Ren 👋 
I’m using your plugin on a few test and staging sites. Thanks for the plugin!

In this pull request, I’ve made a few adjustments to the default template that caught my eye.
Firstly, there’s a minor visual display issue where the input field is incorrectly indented.

Before:
<img width="856" height="508" alt="CleanShot 2026-03-18 at 09 05 22@2x" src="https://github.com/user-attachments/assets/4f806d57-482d-45b7-9d94-fa661aa23ba5" />

After:
<img width="872" height="480" alt="CleanShot 2026-03-18 at 09 06 22@2x" src="https://github.com/user-attachments/assets/ea3fd36e-83b0-4b73-8aaa-3813d18b2ee2" />

The other changes resolve accessibility issues with the input element and the document structure.